### PR TITLE
Download data: added CSV download functionality

### DIFF
--- a/main/html/index.html
+++ b/main/html/index.html
@@ -346,7 +346,7 @@
          <!--
       Space for download data buttons.
       -->
-      <div className="downloadDataButtons" id="downloadDataButtons">
+      <div className="downloadDataButtons" id="downloadDataButtons" align="center">
       </div>
 
         <!--
@@ -367,7 +367,7 @@
               Setting up the plots to go under each tab.
             -->
             <div id="heatmapRef" class="col s12">
-              <div id="heatmapDiv0" style="margin-top: 25px"></div>
+              <div id="heatmapDiv0" style="margin-top: 25px" align="center"></div>
             </div>
             <div id="violinPlotRef" class="col s12">
               <div

--- a/main/html/index.html
+++ b/main/html/index.html
@@ -343,6 +343,12 @@
           </button>
         </div>
 
+         <!--
+      Space for download data buttons.
+      -->
+      <div className="downloadDataButtons" id="downloadDataButtons">
+      </div>
+
         <!--
         Setting up the tabs.
       -->

--- a/main/js/afterSubmit.js
+++ b/main/js/afterSubmit.js
@@ -126,18 +126,18 @@ let buildPlots = async function () {
     .map((gene) => gene.text);
 
   // Fetch RNA sequencing data for selected cancer cohort(s) and gene(s)
-  let expressionData = await getExpressionDataJSONarray_cg(
+  let expressionData_1 = await getExpressionDataJSONarray_cg(
     cohortQuery,
     gene1Query
   );
 
   // Find intersecting barcodes based on Mutation/Clinical Pie Chart selections
   let intersectedBarcodes = await getBarcodesFromSelectedPieSectors(
-    expressionData
+    expressionData_1
   );
 
   // Extract expression data only at intersectedBarcodes
-  let data = await getExpressionDataFromIntersectedBarcodes(
+  let expressionData = await getExpressionDataFromIntersectedBarcodes(
     intersectedBarcodes,
     cohortQuery
   );
@@ -158,12 +158,13 @@ let buildPlots = async function () {
     );
   }
 
+  expressionData = expressionData.filter(el => el.sample_type==="TP") // quick fix. queried data includes normal samples ("NT"), this needs to be fixed in "getExpressionDataFromIntersectedBarcodes"
   //Add expression data as a field in localStorage
-  localStorage.setItem("expressionData", JSON.stringify(data));
+  localStorage.setItem("expressionData", JSON.stringify(expressionData));
 
-  buildDownloadData(cohortQuery, gene2Query, clinicalQuery, data, clinicalData);
-  buildHeatmap(data, clinicalData);
-  buildViolinPlot(cohortQuery, data);
+  buildDownloadData(cohortQuery, gene2Query, clinicalQuery, expressionData, clinicalData);
+  buildHeatmap(expressionData, clinicalData);
+  buildViolinPlot(cohortQuery, expressionData);
 };
 
 buildHeatmap = async function (expData, clinData) {
@@ -314,11 +315,6 @@ buildDownloadData = async function (cohortID, genes, clin_vars, expressionData, 
       else { csv_string_clin += val } // add to string
     })
   })
-
-  console.log("Debug data")
-  console.log(expressionData)
-  console.log(barcodes_exp)
-  console.log(barcodes_exp.join(","))
 
   // clear div and add new button for json, csv_exp, csv_clin
   d3.select("#downloadDataButtons").html("");

--- a/main/js/afterSubmit.js
+++ b/main/js/afterSubmit.js
@@ -305,5 +305,5 @@ buildDownloadData = async function (
     .on("click", function () {
       saveFile(JSON.stringify(saveObject), "WebGen_data.json");
     })
-    .text("Download data as JSON");
+    .text("Download (JSON)");
 };


### PR DESCRIPTION
CSV download implemented, can download expression data and clinical data as separate files (WebGen_expression.csv, WebGen_clinical.csv) containing array of comma separated values for gene expression (z-score) or clinical features.

Can add a second button for expression_log2 values as a csv (just z-scores currently)

Found one issue with the expression data, the object contains normal tissue samples (sample_type=="NT", instead of "TP" for tumor). We decided earlier not to include normal data, so this needs to be fixed in the getExpressionDataFromIntersectedBarcodes function. I put in a quick fix to just filter out by sample_type, but the real solution is just adding a line to the query parameters for sample_type. Will take a look.

Kevin Z - turned off the styling you implemented because it was cutting off the button text, maybe there is a fix