### PR TITLE
days_to_death & cervix_suv_results now show as histograms

### DIFF
--- a/main/js/fillSelectBoxes.js
+++ b/main/js/fillSelectBoxes.js
@@ -321,7 +321,7 @@ let fillClinicalSelectBox = async function () {
       var nullCount = continuousMap.filter(x => x == null).length;
       var totalCount = continuousMap.length;
       var percentContinuous = nullCount / totalCount;
-      if(percentContinuous < 0.75 & (currentFeature != 'vital_status'))
+      if((percentContinuous < 0.75 && (currentFeature != 'vital_status')) || currentFeature === "days_to_death" || currentFeature === "cervix_suv_results")
         temp.type = "continuous";
       else
         temp.type = "categorical";


### PR DESCRIPTION
Fixed issue with days_to_death and cervix_suv_results showing up as pie charts when they have continuous data. They now show up as histograms.