### PR TITLE
remove duplicate d3 loading

### DIFF
--- a/main/html/index.html
+++ b/main/html/index.html
@@ -18,7 +18,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 
     <!-- Load d3.js -->
-    <script src="https://d3js.org/d3.v4.js"></script>
     <script src="https://d3js.org/d3.v4.min.js"></script>
 
     <!-- Load jQuery -->


### PR DESCRIPTION
fixes #285 

this proposes removing a duplicate d3 load in `index.html`. the min version of d3 should have everything the non-min version has.