### PR TITLE
remove duplicate d3.js load

### DIFF
--- a/main/html/index.html
+++ b/main/html/index.html
@@ -15,7 +15,6 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 
         <!-- Load d3.js -->
-        <script src="https://d3js.org/d3.v4.js"></script>
         <script src="https://d3js.org/d3.v4.min.js"></script>
 
         <!-- Load jQuery -->


### PR DESCRIPTION
Fixes https://github.com/web4bio/webgen/issues/285

The min version of d3 is the same as the non-min version, except it is
minified (ie smaller memory footprint).

replaces #292 