### PR TITLE
improve lighthouse scores (performance and best practices)

### DIFF
--- a/main/html/index.html
+++ b/main/html/index.html
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width">
+        <title>WebGen | explore cancer data from The Cancer Genome Atlas</title>
 
         <!-- Critical resources are loaded early. Non-critical resources are deferred. -->
         <!-- jquery -->

--- a/main/html/index.html
+++ b/main/html/index.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+
         <!-- Critical resources are loaded early. Non-critical resources are deferred. -->
         <!-- jquery -->
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/main/html/index.html
+++ b/main/html/index.html
@@ -6,7 +6,7 @@
 
         <!-- Critical resources are loaded early. Non-critical resources are deferred. -->
         <!-- jquery -->
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
         <!-- materialize -->
         <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" />

--- a/main/html/index.html
+++ b/main/html/index.html
@@ -1,64 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
-    <!--
-  Uses a user input for the cohort list and gene list. These input lists should be comma separated values.
--->
-
-    <!--
-    Importing jobs:
-  -->
     <head>
-        <!-- Compiled and minified CSS -->
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" />
-
-        <!-- Compiled and minified JavaScript -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-
-        <!-- Load d3.js -->
-        <script src="https://d3js.org/d3.v4.js"></script>
-        <script src="https://d3js.org/d3.v4.min.js"></script>
-
-        <!-- Load jQuery -->
+        <!-- Critical resources are loaded early. Non-critical resources are deferred. -->
+        <!-- jquery -->
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-
-        <!-- Load Jonas's FireBrowse library -->
-        <script src="https://episphere.github.io/firebrowse/firebrowse.js"></script>
-
-        <!-- Load hclust library (for clustering) -->
-        <script src="../js/libraries/hclust.min.js"></script>
-
-        <!-- Load color palettes -->
-        <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
-
-        <!-- Select2 Library -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/3.5.4/select2.min.js"></script>
+        <!-- materialize -->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" />
+        <!-- Jonas's FireBrowse library -->
+        <script src="https://episphere.github.io/firebrowse/firebrowse.js" defer></script>
+        <!-- hclust for clustering -->
+        <script src="../js/libraries/hclust.min.js" defer></script>
+        <!-- Select2 -->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/3.5.4/select2.min.js" defer></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2/3.5.4/select2.min.css" />
-
-        <!-- lodash Library for pagination -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.15.0/lodash.min.js"></script>
-
-        <!-- Plotly Library -->
-        <script type="text/javascript" src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-
-        <!-- Load hclust library (for clustering) -->
-        <script src="../js/libraries/hclust.min.js"></script>
-
-        <!-- Load in files -->
+        <!-- lodash for pagination -->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.15.0/lodash.min.js" defer></script>
+        <!-- d3 -->
+        <script src="https://d3js.org/d3.v4.min.js" defer></script>
+        <script src="https://d3js.org/d3-scale-chromatic.v1.min.js" defer></script>
+        <!-- plotly -->
+        <script type="text/javascript" src="https://cdn.plot.ly/plotly-latest.min.js" defer></script>
+        <!-- webgen styles and javascript -->
         <link rel="stylesheet" type="text/css" href="../css/style.css" />
-
-        <script type="text/javascript" src="../js/dataAcquisition/fetchClinicalData.js"></script>
-        <script type="text/javascript" src="../js/dataAcquisition/fetchExpressionData.js"></script>
-        <script type="text/javascript" src="../js/dataAcquisition/getClinicalDataJSONarray.js"></script>
-        <script type="text/javascript" src="../js/dataAcquisition/getDataFromSelectedPieSectors.js"></script>
-        <script type="text/javascript" src="../js/dataAcquisition/getExpressionDataJSONarray.js"></script>
-
-        <script type="text/javascript" src="../js/dataProcessing/mergeExpression.js"></script>
-
-        <script type="text/javascript" src="../js/plots/createHeatmap.js"></script>
-        <script type="text/javascript" src="../js/plots/createViolinPlot.js"></script>
-
-        <script type="text/javascript" src="../js/afterSubmit.js"></script>
-        <script type="text/javascript" src="../js/fillSelectBoxes.js"></script>
+        <script src="../js/fillSelectBoxes.js"></script>
+        <script src="../js/dataAcquisition/fetchClinicalData.js" defer></script>
+        <script src="../js/dataAcquisition/fetchExpressionData.js" defer></script>
+        <script src="../js/dataAcquisition/getClinicalDataJSONarray.js" defer></script>
+        <script src="../js/dataAcquisition/getDataFromSelectedPieSectors.js" defer></script>
+        <script src="../js/dataAcquisition/getExpressionDataJSONarray.js" defer></script>
+        <script src="../js/dataProcessing/mergeExpression.js" defer></script>
+        <script src="../js/plots/createHeatmap.js" defer></script>
+        <script src="../js/plots/createViolinPlot.js" defer></script>
+        <script src="../js/afterSubmit.js" defer></script>
     </head>
 
     <body>
@@ -224,11 +198,11 @@
 
                 <!-- <div>
         <p style="text-align: center;"><b>3) Click pie sectors to define gene types </b></p>
-        <p style="text-align: center; color: gray">Hint 1: Click items in legend to change view of plot</p> 
-        <p style="text-align: center; color: gray">Hint 2: In plot, click on wild-type or mutated genes that you would like to visualize. Selected data will be highlighted <b><span style="color: orange">yelllow</span></b>.</p> 
+        <p style="text-align: center; color: gray">Hint 1: Click items in legend to change view of plot</p>
+        <p style="text-align: center; color: gray">Hint 2: In plot, click on wild-type or mutated genes that you would like to visualize. Selected data will be highlighted <b><span style="color: orange">yelllow</span></b>.</p>
         </div> -->
 
-                <!-- 
+                <!--
           Data exploration div
         -->
                 <div class="row" id="dataexploration">

--- a/main/html/index.html
+++ b/main/html/index.html
@@ -18,7 +18,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/3.5.4/select2.min.js" defer></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2/3.5.4/select2.min.css" />
         <!-- lodash for pagination -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.15.0/lodash.min.js" defer></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js" defer></script>
         <!-- d3 -->
         <script src="https://d3js.org/d3.v4.min.js" defer></script>
         <script src="https://d3js.org/d3-scale-chromatic.v1.min.js" defer></script>

--- a/main/html/index.html
+++ b/main/html/index.html
@@ -23,7 +23,7 @@
         <script src="https://d3js.org/d3.v4.min.js" defer></script>
         <script src="https://d3js.org/d3-scale-chromatic.v1.min.js" defer></script>
         <!-- plotly -->
-        <script type="text/javascript" src="https://cdn.plot.ly/plotly-latest.min.js" defer></script>
+        <script src="https://cdn.plot.ly/plotly-2.5.0.min.js" defer></script>
         <!-- webgen styles and javascript -->
         <link rel="stylesheet" type="text/css" href="../css/style.css" />
         <script src="../js/fillSelectBoxes.js"></script>

--- a/main/html/index.html
+++ b/main/html/index.html
@@ -340,23 +340,24 @@
                             <h7 class="white-text">LINKS</h7>
                             <ul>
                                 <li>
-                                    <a target="_blank" class="grey-text text-lighten-3" href="https://github.com/web4bio/webgen"
+                                    <a target="_blank" rel="noopener" class="grey-text text-lighten-3" href="https://github.com/web4bio/webgen"
                                         >GitHub</a
                                     >
                                 </li>
                                 <li>
-                                    <a target="_blank" class="grey-text text-lighten-3" href="http://firebrowse.org/api-docs/"
+                                    <a target="_blank" rel="noopener" class="grey-text text-lighten-3" href="http://firebrowse.org/api-docs/"
                                         >Firebrowse API</a
                                     >
                                 </li>
                                 <li>
-                                    <a target="_blank" class="grey-text text-lighten-3" href="https://gdc.cancer.gov/"
+                                    <a target="_blank" rel="noopener" class="grey-text text-lighten-3" href="https://gdc.cancer.gov/"
                                         >NCI Genomic Data Commons</a
                                     >
                                 </li>
                                 <li>
                                     <a
                                         target="_blank"
+                                        rel="noopener"
                                         class="grey-text text-lighten-3"
                                         href="https://www.stonybrook.edu/commcms/vertically-integrated-projects/teams/_team_page/team_page.php?team=WebGen%20(Web%20Genomics)"
                                         >Stony Brook University VIP</a

--- a/main/html/index.html
+++ b/main/html/index.html
@@ -22,7 +22,6 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js" defer></script>
         <!-- d3 -->
         <script src="https://d3js.org/d3.v4.min.js" defer></script>
-        <script src="https://d3js.org/d3-scale-chromatic.v1.min.js" defer></script>
         <!-- plotly -->
         <script src="https://cdn.plot.ly/plotly-2.5.0.min.js" defer></script>
         <!-- webgen styles and javascript -->


### PR DESCRIPTION
this pull request improves page loads and best practices, as measured by lighthouse. the bulk of the speed improvement comes from deferring loading and execution of non-critical javascript files, using the [`defer` attribute of the script tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer). the best practices include setting charset,  viewport, and title, as well as using `rel="noopener"` in cross-origin links.

this pull request also proposes upgrading jquery and lodash versions, because newer versions patched known security vulnerabilities. the pr also pins plotly to 2.5.0 instead of using 'latest'.

## Lighthouse score of this pull request
![Screenshot from 2021-09-12 14-20-00](https://user-images.githubusercontent.com/17690870/132998520-1bf4b793-958f-4829-b432-c8fc457f1ef8.png)

## Lighthouse score of development branch
![Screenshot from 2021-09-12 14-21-18](https://user-images.githubusercontent.com/17690870/132998524-e13dffc7-17d1-4ccd-ab57-5af4bc978435.png)

related to #294 