### PR TITLE
hide tab anchors by default but show after submit

### DIFF
--- a/main/html/index.html
+++ b/main/html/index.html
@@ -290,13 +290,12 @@
                 <!--
         Setting up the tabs.
       -->
-                <div class="tabs_container">
+                <div>
                     <div class="col s36">
-                        <ul class="tabs tabs-fixed-width tab-demo z-depth-1">
+                        <ul class="tabs tabs-fixed-width tab-demo z-depth-1" id="tabsForPlots" style="display: none;">
                             <li class="tab col s12">
                                 <a class="active" href="#heatmapRef">Heatmap</a>
                             </li>
-                            <!-- <li class="tab col s12"><a href="#boxWhiskRef">Box and Whisker Plot</a></li> -->
                             <li class="tab col s12">
                                 <a href="#violinPlotRef">Violin Plot</a>
                             </li>

--- a/main/js/afterSubmit.js
+++ b/main/js/afterSubmit.js
@@ -127,11 +127,11 @@ let buildPlots = async function () {
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   // PAGE SETUP:
-  
+
   // Reset page formatting:
   document.getElementById("heatmapLoaderDiv").innerHTML = "";
   document.getElementById("violinLoaderDiv").innerHTML = "";
-  
+
   // Display loader:
   document.getElementById("heatmapLoaderDiv").className = "loader";
   document.getElementById("violinLoaderDiv").className = "loader";
@@ -151,7 +151,7 @@ let buildPlots = async function () {
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   // GET EXPRESSION DATA:
-  
+
   // Fetch expression data for selected cancer cohort(s) and gene(s)
   let expressionData_1 = await getExpressionDataJSONarray_cg(cohortQuery, mutationQuery);
 
@@ -170,10 +170,10 @@ let buildPlots = async function () {
   let clinicalData;
   if (intersectedBarcodes && intersectedBarcodes.length) {
     clinicalData = (await firebrowse.getClinical_FH_b(intersectedBarcodes)).Clinical_FH;
-  } else { 
+  } else {
     clinicalData = await getClinicalDataJSONarray_c(cohortQuery);
   }
-  
+
   localStorage.setItem("clinicalData", JSON.stringify(clinicalData));
   localStorage.setItem("clinicalFeatureKeys", Object.keys(clinicalData[0]));
 
@@ -219,7 +219,7 @@ buildHeatmap = async function (expData, clinData) {
   // Create the heatmap
   createHeatmap(expData, clinData, divHeatMap);
 };
- 
+
 addToggleSwitch = async function(expressionQuery, cohortQuery, expressionData) {
 
   // Remove the loader
@@ -269,7 +269,7 @@ addToggleSwitch = async function(expressionQuery, cohortQuery, expressionData) {
   });
 }
 
-  buildViolinPlot = async function (cohortORGeneQuery, data, independantVarType) { 
+  buildViolinPlot = async function (cohortORGeneQuery, data, independantVarType) {
 
     addDiv("violinPlots", "toggleSwitchDiv");
 
@@ -401,11 +401,11 @@ buildDownloadData = async function (cohortID, expressionData, clinicalData) {
             csv_string_expZscore += ",";
             csv_string_expLog2 += ",";
             // filter out one barcode/gene combination
-            let valZ = expressionData 
+            let valZ = expressionData
                 .filter((el) => el.tcga_participant_barcode === b && el.gene === g)
                 .map((el) => el["z-score"]); // zscore value to add to zscore csv
             if (!valZ.length) { csv_string_expZscore += "NA"; } else { csv_string_expZscore += valZ; }; // add to string
-            let valL = expressionData 
+            let valL = expressionData
                 .filter((el) => el.tcga_participant_barcode === b && el.gene === g)
                 .map((el) => el.expression_log2); // log2 value to add to log2 csv
             if (!valL.length) { csv_string_expLog2 += "NA"; } else { csv_string_expLog2 += valL; }; // add to string
@@ -459,7 +459,6 @@ buildDownloadData = async function (cohortID, expressionData, clinicalData) {
         $("#downloadClinicalButton")
             .on("click", function () {alert("Clinical data is empty. Please select clinical features to save.")});
     };
-    $("#downloadDataButtons")
-        .show()
+    $("#downloadDataButtons").show()
+    $("ul#tabsForPlots").show()
 };
-


### PR DESCRIPTION
this pr proposes hiding the tabs "heatmap | violin plots" initially. they are shown only after the requests finish.

the same behavior already applies to the data download buttons.

fixes #305 