### PR TITLE
fix: highlight heatmap tab after submit is complete

### DIFF
--- a/main/html/index.html
+++ b/main/html/index.html
@@ -292,7 +292,7 @@
       -->
                 <div>
                     <div class="col s36">
-                        <ul class="tabs tabs-fixed-width tab-demo z-depth-1" id="tabsForPlots" style="display: none;">
+                        <ul class="tabs tabs-fixed-width tab-demo z-depth-1" style="display: none;">
                             <li class="tab col s12">
                                 <a class="active" href="#heatmapRef">Heatmap</a>
                             </li>

--- a/main/js/afterSubmit.js
+++ b/main/js/afterSubmit.js
@@ -468,5 +468,6 @@ buildDownloadData = async function (cohortID, expressionData, clinicalData) {
             .on("click", function () {alert("Clinical data is empty. Please select clinical features to save.")});
     };
     $("#downloadDataButtons").show()
-    $("ul#tabsForPlots").show()
+    $("ul.tabs").show()
+    instance.updateTabIndicator()
 };


### PR DESCRIPTION
this fixes a bug introduced by #310. the bug was that both tabs were highlighted after the submit query completed. when writing #310, i didn't realize that javascript interacted with the tabs. this pr this the problem by using the `.updateTabIndicator()` of the materialize tabs instance. 