### PR TITLE
add jsdocs + use URLSearchParams + rm old comments

### DIFF
--- a/main/js/dataAcquisition/fetchExpressionData.js
+++ b/main/js/dataAcquisition/fetchExpressionData.js
@@ -16,7 +16,6 @@
  * @returns {Promise<{mRNASeq: mRNASeqItem[]}>} Object with fetched data.
  *
  * @throws {Error} if fetch response is not OK.
- * @throws {Error} if fetched data is empty. We expect an mRNASeq key in this object.
  *
  * @example
  *   fetchExpressionData_cg("BLCA", "bcl2")
@@ -38,14 +37,17 @@ async function fetchExpressionData_cg(cohortQuery, geneQuery) {
     });
 
     const response = await fetch(`${hosturl}?${endpointurl}?${params.toString()}`);
+    const minimal_json = { mRNASeq: [] };
     if (!response.ok) {
-        throw new Error("Fetching mRNASeq data was unsuccessful.");
+        console.log("Fetching mRNASeq data was unsuccessful.")
+        return minimal_json
     }
     const json = await response.json();
     // We expect at least an mRNASeq key, so if this json object is empty, there's
     // a problem.
     if (!json) {
-        throw new Error("mRNASeq data is empty.")
+        console.log("mRNASeq is empty, returning an object with empty mRNASeq")
+        return minimal_json
     }
     return json
 }


### PR DESCRIPTION
This PR is meant to help some of the younger students get started with jsdocs. This should serve as an example of how one can write documentation in the style of jsdocs. I referred to https://jsdoc.app/ and https://devhints.io/jsdoc for examples and good practices.

This commit adds documentation in the style of jsdocs. Nice! To do this,
I added `console.log` calls to print the variables that were going into
and out of the function. That allowed me to figure out the types for
arguments and the structure of the returned object. To describe the
returned object, I used a typedef. This typedef defines one item in the
returns object, and the returned object includes an array of these
items.

I have several questions after working on this function.
1. How should we handle calls to `fetch`? In this function, we check
   whether the output is an empty string. But would it ever be? Would it
   make more sense to check the response's return code? Or perhaps use a
   try-catch and log errors?
2. We return an array if `fetch` returns an empty string. Do we do
   anything with this array? It seems like a `console.log` would suffice
   here. Actually, I will look into the call stack and probably change
   this to a `console.log`.

I came across `URLSearchParams` to build a url query. https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams it's cleaner than concatenating multiple strings.

I removed the commented lines because the functions exist in git's memory of our project. If we need to go back to them, we can checkout to a previous commit.