### PR TITLE
ENH: add jsdoc to mergeExpression

### DIFF
--- a/main/js/dataProcessing/mergeExpression.js
+++ b/main/js/dataProcessing/mergeExpression.js
@@ -4,7 +4,7 @@
  * The expression array order is specified by gene names.
  *
  * @param {mRNASeqItem[]} dataInput - The data to transform.
- * @returns {{id: string, exps: (number|null)[], genes: string[], id: string}[]} - Transformed data.
+ * @returns {{id: string, exps: (number|null)[], genes: string[]}[]} - Transformed data.
  */
 const mergeExpression = function(dataInput) {
   const unique_genes = d3.map(dataInput, d => d.gene).keys();


### PR DESCRIPTION
This adds a jsdoc comment to `mergeExpression`. It also shortens the arrow functions and replaces `var` with `const`.