### PR TITLE
add eslint as default linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,58 @@
+{
+    "extends": "eslint:recommended",
+    "env": {
+        "browser": true,
+        "es6": true,
+        "jquery": true
+    },
+    "parserOptions": {
+        "ecmaVersion": 2015
+    },
+    "rules": {
+        // Validate jsdoc comments.
+        "valid-jsdoc": "error",
+        // Can't use a variable before it is defined.
+        "no-use-before-define": "error",
+        // No unused vars.
+        "no-unused-vars": [
+            "error",
+            {
+                // Unused globals are ok (e.g., functions that are used elsewhere).
+                "vars": "local"
+            }
+        ],
+        // Async functions must include await.
+        "require-await": "error",
+        // Use === and !== instead of == and !=.
+        "eqeqeq": [
+            "error",
+            "smart"
+        ],
+        // Use let or const instead of var.
+        "no-var": "error",
+        // Prefer using const instead of let when possible.
+        "prefer-const": "error",
+        // Prefer template strings instead of string concatenation.
+        "prefer-template": "warn",
+        // Use double quotes when possible.
+        "quotes": [
+            "error",
+            "double"
+        ],
+        // Enforce a consistent use of semicolons.
+        "semi": [
+            "error",
+            "always"
+        ],
+        // Indent with this many spaces.
+        "indent": [
+            "error",
+            2
+        ],
+        // Max line length.
+        "max-len": [
+            "error",
+            100
+        ]
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,14 @@
 {
+    "eslint.format.enable": true,
+    "eslint.lintTask.enable": true,
+    "eslint.validate": [
+        "javascript"
+    ],
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
+    "eslint.run": "onSave",
+    "editor.formatOnSave": true,
+    "editor.trimAutoWhitespace": true,
     "liveServer.settings.port": 5501
 }


### PR DESCRIPTION
this is a draft PR at this point. it includes an example eslint config file and updates the vscode workspace settings to run eslint whenever a file is saved.

closes #332 