### PR TITLE
fix jsdoc return type in mergeExpression func

### DIFF
--- a/main/js/dataProcessing/mergeExpression.js
+++ b/main/js/dataProcessing/mergeExpression.js
@@ -4,7 +4,7 @@
  * The expression array order is specified by gene names.
  *
  * @param {mRNASeqItem[]} dataInput - The data to transform.
- * @returns {{id: string, exps: (number|null)[], genes: string[]}[]} - Transformed data.
+ * @returns {Array.<{id: string, exps: Array.<(number|null)>, genes: string[]}>} - Transformed data.
  */
 const mergeExpression = function(dataInput) {
   const unique_genes = d3.map(dataInput, d => d.gene).keys();


### PR DESCRIPTION
jsdoc complained about the return type in this function. this commit resolves that problem. the fix is to use `Array.<TYPE>` instead of `TYPE[]`. i am confused, however, because sometimes using `TYPE[]` does work.

let's wait on this PR until #328 is merged.