### PR TITLE
ENH: rm d3 in mergeexpression

### DIFF
--- a/main/js/dataProcessing/mergeExpression.js
+++ b/main/js/dataProcessing/mergeExpression.js
@@ -16,8 +16,14 @@
  * @returns {Array.<{id: string, exps: Array.<?number>, genes: string[]}>} - Transformed data.
  */
 const mergeExpression = function(dataInput) {
-  const unique_genes = d3.map(dataInput, d => d.gene).keys();
-  const unique_ids = d3.map(dataInput, d => d.tcga_participant_barcode ).keys();
+
+  const getUniqueValues = function(arr, key) {
+    const arrOfVals = arr.map(a => a[key]);
+    return [... new Set(arrOfVals)];
+  };
+
+  const unique_genes = getUniqueValues(dataInput, "gene");
+  const unique_ids = getUniqueValues(dataInput, "tcga_participant_barcode");
 
   const data_raw = dataInput.map(({tcga_participant_barcode,expression_log2, gene}) => ({id:tcga_participant_barcode, exp:expression_log2, gene, geneInd:unique_genes.indexOf(gene)}));
 


### PR DESCRIPTION
This commit uses vanilla ES6 to get the unique values from an array of
objects. This removes the need for d3 in this script. This is helpful
because now this script is encapsulated, meaning it stands on its own
and doesn't need anything else loaded to work.