### PR TITLE
Optimal Query Size Parameters

### DIFF
--- a/main/js/dataAcquisition/fetch.js
+++ b/main/js/dataAcquisition/fetch.js
@@ -294,11 +294,11 @@ firebrowse.fetchmRNASeq = async function({cohorts, genes, barcodes}) {
   const groupBy = [];
   if (genes) {
     params.gene = genes;
-    groupBy.push({key: "gene", length: 20});
+    groupBy.push({key: "gene", length: 1});
   }
   if (barcodes) {
     params.tcga_participant_barcode = barcodes;
-    groupBy.push({key: "tcga_participant_barcode", length: 50});
+    groupBy.push({key: "tcga_participant_barcode", length: 100});
   }
   const data = await firebrowse.fetch("/Samples/mRNASeq", params, groupBy);
   return data.mRNASeq;


### PR DESCRIPTION
#385 Changed the query size parameters so that the gene length is 1 and the tcga_participant_barcode length is 100. This combination is producing results with great response times.