### PR TITLE
Update conf.json

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -3,6 +3,7 @@
   "recurseDepth": 10,
   "source": {
       "include": ["./main/js/"],
+      "exclude": ["./main/js/smartCache/"],
       "includePattern": ".+\\.js(doc|x)?$",
       "excludePattern": "(^|\\/|\\\\)_"
   },


### PR DESCRIPTION
Interface is a reserved word in jsdoc, added an ignore path in the conf.json file as a simple/lazy fix to prevent any other part of the code from breaking if the SmartCache's interface property has its named changed.